### PR TITLE
Do not tag clients with nil tag

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -157,7 +157,7 @@ local function match_client(c, startup)
     end
     --Add to the current tag if not exclusive
     local cur_tag = awful.tag.selected(c.screen)
-    if awful.tag.getproperty(cur_tag,"exclusive") ~= true then
+    if cur_tag and awful.tag.getproperty(cur_tag,"exclusive") ~= true then
         c:tags({cur_tag})
         capi.client.focus = c
         return true


### PR DESCRIPTION
With no selected tag (e.g. during startup, as long as no client with a
rule has been processed), cur_tag would be nil and then the match for
exclusive would be ~= true.
