### PR TITLE
Exec once

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -28,8 +28,6 @@ local function on_selected_change(tag,data)
         for _,v in ipairs(type(data.exec_once) == "string" and {data.exec_once} or data.exec_once) do
             awful.util.spawn_with_shell("ps -ef | grep -v grep | grep '" .. v .. "' > /dev/null || (" .. v .. ")")
         end
-
-        --data._init_done = true
     end
 end
 


### PR DESCRIPTION
More robust matching to provide some functionality from shifty that I missed. Now the exec_once command(s) will always fire, provided they're not already running.

My use cases: 
1. I have mocp automatically open when I hit my music tab, but i close the console when I'm done and let moc continue to play. When I go back to the tab, the console pops up again.
1. Always open three terminal emulators on my dev console, unless any are currently open.

``` lua
exec_once = {
    "urxvt -name dev",
    "urxvt -name dev",
    "urxvt -name dev"
}
```
