### PR TITLE
Correctly fullscreen clients

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -85,11 +85,35 @@ function module.focus_client(c,properties)
     local properties = properties or (c_rules.instance[string.lower(c.instance or "N/A")] or {}).properties or (c_rules.class[string.lower(get_class(c))] or {}).properties or {}
     if (((not c.transient_for) or (c.transient_for==capi.client.focus) or (not settings.block_children_focus_stealing)) and (not properties.no_autofocus)) then
         if not awful.util.table.hasitem(c:tags(), awful.tag.selected(c.screen or 1)) and (not prop(c:tags()[1],"no_focus_stealing_in")) then
+            -- Reload maximized or fullscreen state
+            module.reload_max_client(c)
+            -- Focus on tag
             awful.tag.viewonly(c:tags()[1])
         end
         capi.client.focus = c
         c:raise()
         return true
+    end
+end
+
+--Check all maximized or fullscreen policies then reload
+function module.reload_max_client(c)
+    if c.maximized then
+        c.maximized = false
+        c.maximized = true
+    else
+        if c.maximized_horizontal then
+            c.maximized_horizontal = false
+            c.maximized_horizontal = true
+        end
+        if c.maximized_vertical then
+            c.maximized_vertical = false
+            c.maximized_vertical = true
+        end
+    end
+    if c.fullscreen then
+        c.fullscreen = false
+        c.fullscreen = true
     end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -198,7 +198,7 @@ capi.client.connect_signal("manage", match_client)
 capi.client.connect_signal("untagged", function (c, t)
     if prop(t,"volatile") == true and #t:clients() == 0 then
         local rules = c_rules.class[string.lower(get_class(c))]
-        c_rules.class[string.lower(get_class(c))] = (prop(t,"onetimer") ~= true or c.class == nil) and rules or nil --Prevent "last resort tags" from persisting
+        c_rules.class[string.lower(get_class(c))] = (prop(t,"onetimer") ~= true or get_class(c) == nil) and rules or nil --Prevent "last resort tags" from persisting
         for j=1,#(rules and rules.tags or {}) do
             rules.tags[j].instances[c.screen] = rules.tags[j].instances[c.screen] ~= t and rules.tags[j].instances[c.screen] or nil
         end


### PR DESCRIPTION
This corrects a problem with fullscreen and dual screen. The problem also happens with maximized clients.
When the second screen is not the same size as the first screen, new fullscreen clients (for instance Libreoffice presentation) seem to be first fullscreened in the first screen, then moved to the second screen. However it is not really fullscreened in the second screen, but it keeps the size of the first screen instead.
This should be corrected directly in awful I assume, but this is a temporary patch.
It basically set fullscreen to false then to true again once the client is in the proper screen.

This commit also correct a bug from PR #39, by replacing one instance of c.class that was omitted by get_class(c).
