### PR TITLE
Implement no_focus_only-property for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Similar to `no_focus_stealing_in`. If a tag enable this, then the tag will stay
 selected no matter what event happen. This is useful for video games and video
 players.
 
+**no_tag_deselect:**
+When a new client is added somewhere, that tag gets selected in addition to the
+current selection of tags instead of being selected solely.
+
 **no_autofocus:**
 When a class has this flag, then new clients wont be focused when they are
 launched. This is useful for download managers or background terminals tasks.
@@ -277,6 +281,7 @@ Then edit this section to fit your needs.
 | **master_count**          | Number of master clients                             | number           |
 | **no_focus_stealing_in**  | Do not select this tag when a new client is added    | boolean          |
 | **no_focus_stealing_out** | Do not unselect when a new client is added elsewhere | boolean          |
+| **no_tag_deselect**       | Do not unselect other tags spawning/selecting this   | boolean          |
 | **screen**                | Tag screen(s)                                        | number or array  |
 | **selected**              | Select when created                                  | boolean          |
 | **volatile**              | Destroy when the last client is closed               | boolean          |

--- a/init.lua
+++ b/init.lua
@@ -114,7 +114,12 @@ function module.focus_client(c,properties)
         local tags = c:tags()
 
         if #tags > 0 and not has_selected(tags, c.screen) and not tags[1].no_focus_stealing_in then
-            c:tags()[1]:view_only()
+            local t = c:tags()[1]
+            if t.no_tag_deselect then
+                t.selected = true
+            else
+                t:view_only()
+            end
         end
 
         capi.client.focus = c


### PR DESCRIPTION
With no_focus_only, a tag can be denoted that adding a client there
should select that tag, but should never deselect other tags that are
currently selected.